### PR TITLE
Image extent half-pixel margin in pyplot

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -756,7 +756,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
             cmap = py_colormap(cgrad([:black, :white])),
             vmin = 0.0,
             vmax = 1.0,
-            extent = (xmin, xmax, ymax, ymin)
+            extent = (xmin-0.5, xmax+0.5, ymax+0.5, ymin-0.5)
         )
         push!(handles, handle)
 


### PR DESCRIPTION
Adds a half-pixel margin to the extent for image plots so that the pixel coordinates match the grid, i.e. the center of each square pixel lies over its integral index numbers, and each square covers half a pixel before and after that.